### PR TITLE
Add basic client and server structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# Sam2
+# Sam2 Demo Project
+
+This repository contains a small demo with a Node backend and a minimal HTML frontend. The project is organized into two folders:
+
+- `server/` – contains the backend code and a simple HTTP server built with Node's built-in modules
+- `client/` – contains static HTML files
+
+## Running locally
+
+1. Ensure Node.js 18+ is installed.
+2. From the repository root, start the server:
+
+```bash
+node server/index.js
+```
+
+3. Open `http://localhost:3000` in your browser to view the site.
+
+The backend serves API endpoints under `/api` and also hosts the static files in the `client` directory.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Patients</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    ul { list-style: none; padding: 0; }
+    li { margin: 5px 0; }
+  </style>
+</head>
+<body>
+  <h1>Patients</h1>
+  <ul id="patient-list"></ul>
+<script>
+fetch('/api/patients')
+  .then(r => r.json())
+  .then(data => {
+    const list = document.getElementById('patient-list');
+    data.forEach(p => {
+      const li = document.createElement('li');
+      li.innerHTML = `<a href="patient.html?id=${p.id}">${p.name}</a>`;
+      list.appendChild(li);
+    });
+  });
+</script>
+</body>
+</html>

--- a/client/patient.html
+++ b/client/patient.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Patient Details</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    section { margin-bottom: 20px; }
+  </style>
+</head>
+<body>
+  <a href="index.html">&larr; Back to list</a>
+  <h1 id="name"></h1>
+
+  <section>
+    <h2>PRN Medications</h2>
+    <ul id="prn"></ul>
+    <input type="text" id="prn-input" placeholder="Medication">
+    <button onclick="addMedication('prn')">Add</button>
+  </section>
+
+  <section>
+    <h2>Scheduled Medications</h2>
+    <ul id="scheduled"></ul>
+    <input type="text" id="sched-input" placeholder="Medication">
+    <button onclick="addMedication('scheduled')">Add</button>
+  </section>
+
+  <section>
+    <h2>Doctor Notes</h2>
+    <textarea id="notes" rows="4" cols="50"></textarea><br>
+    <button onclick="saveNotes()">Save</button>
+  </section>
+
+<script>
+const params = new URLSearchParams(window.location.search);
+const id = params.get('id');
+
+function load() {
+  fetch(`/api/patients/${id}`)
+    .then(r => r.json())
+    .then(p => {
+      document.getElementById('name').textContent = p.name;
+      const prnList = document.getElementById('prn');
+      prnList.innerHTML = '';
+      p.prn.forEach(m => {
+        const li = document.createElement('li');
+        li.textContent = m;
+        prnList.appendChild(li);
+      });
+      const schedList = document.getElementById('scheduled');
+      schedList.innerHTML = '';
+      p.scheduled.forEach(m => {
+        const li = document.createElement('li');
+        li.textContent = m;
+        schedList.appendChild(li);
+      });
+      document.getElementById('notes').value = p.notes;
+    });
+}
+
+function addMedication(type) {
+  const input = type === 'prn' ? document.getElementById('prn-input') : document.getElementById('sched-input');
+  fetch(`/api/patients/${id}/medications`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type: type, medication: input.value })
+  }).then(() => { input.value=''; load(); });
+}
+
+function saveNotes() {
+  const notes = document.getElementById('notes').value;
+  fetch(`/api/patients/${id}/notes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ notes })
+  }).then(load);
+}
+
+load();
+</script>
+</body>
+</html>

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,75 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+// In-memory patient data
+const patients = Array.from({ length: 10 }, (_, i) => ({
+  id: i + 1,
+  name: `Patient ${i + 1}`,
+  prn: [],
+  scheduled: [],
+  notes: ''
+}));
+
+function sendJSON(res, data, status = 200) {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(data));
+}
+
+const server = http.createServer((req, res) => {
+  const parsed = url.parse(req.url, true);
+  const segments = parsed.pathname.split('/').filter(Boolean);
+
+  // API routes
+  if (segments[0] === 'api' && segments[1] === 'patients') {
+    const id = segments[2] ? parseInt(segments[2]) : null;
+    if (req.method === 'GET' && !id) {
+      const list = patients.map(p => ({ id: p.id, name: p.name }));
+      return sendJSON(res, list);
+    }
+    const patient = patients.find(p => p.id === id);
+    if (!patient) {
+      return sendJSON(res, { error: 'Patient not found' }, 404);
+    }
+    if (req.method === 'GET') {
+      return sendJSON(res, patient);
+    }
+    if (req.method === 'POST') {
+      let body = '';
+      req.on('data', chunk => (body += chunk));
+      req.on('end', () => {
+        let data = {};
+        try { data = JSON.parse(body); } catch {}
+        if (segments[3] === 'medications') {
+          if (data.type === 'prn') patient.prn.push(data.medication);
+          else patient.scheduled.push(data.medication);
+          return sendJSON(res, { ok: true });
+        }
+        if (segments[3] === 'notes') {
+          patient.notes = data.notes || '';
+          return sendJSON(res, { ok: true });
+        }
+        sendJSON(res, { error: 'Invalid request' }, 400);
+      });
+      return;
+    }
+  }
+
+  // Static files
+  const filePath = path.join(__dirname, '..', 'client', parsed.pathname === '/' ? 'index.html' : parsed.pathname);
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.statusCode = 404;
+      res.end('Not found');
+    } else {
+      res.end(content);
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- set up `client/` and `server/` directories
- implement a lightweight Node HTTP server to expose patient data and receive medication updates
- add minimal HTML pages for listing patients and editing individual records
- include instructions for running the server locally in README

## Testing
- `node server/index.js`

------
https://chatgpt.com/codex/tasks/task_e_684dbbf733f08323b43f23140cf00203